### PR TITLE
Make the addition of system checks variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 module "system" {
   source = "git@github.com:kabisa/terraform-datadog-system.git?ref=0.7"
 
+  count = var.system_checks == "yes" ? 1 : 0
+
   locked               = var.locked
   additional_tags      = var.additional_tags
   alert_env            = var.alert_env

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "locked" {
   type    = bool
   default = true
 }
+
+variable "system_checks" {
+  type = string
+  default = "yes"
+  description = "Whether or not to include system checks"
+}


### PR DESCRIPTION
Instead of always adding the checks for the systems as well, make it so we can enable just the service checks, and not also the systems